### PR TITLE
Create initial MAUI Android material management app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dkms.conf
 
 # debug information files
 *.dwo
+# .NET build output
+bin/
+obj/

--- a/MaterialManagerApp.sln
+++ b/MaterialManagerApp.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31611.283
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaterialManagerApp", "MaterialManagerApp/MaterialManagerApp.csproj", "{6A1A2D73-0F2A-4D2A-A90C-6EB2BE47A1F1}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{6A1A2D73-0F2A-4D2A-A90C-6EB2BE47A1F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6A1A2D73-0F2A-4D2A-A90C-6EB2BE47A1F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6A1A2D73-0F2A-4D2A-A90C-6EB2BE47A1F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6A1A2D73-0F2A-4D2A-A90C-6EB2BE47A1F1}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/MaterialManagerApp/App.xaml
+++ b/MaterialManagerApp/App.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MaterialManagerApp.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/MaterialManagerApp/App.xaml.cs
+++ b/MaterialManagerApp/App.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+        MainPage = new AppShell();
+    }
+}

--- a/MaterialManagerApp/AppShell.xaml
+++ b/MaterialManagerApp/AppShell.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Shell
+    x:Class="MaterialManagerApp.AppShell"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:views="clr-namespace:MaterialManagerApp.Views"
+    FlyoutBehavior="Locked"
+    Title="Gestor de Materiales">
+    <Shell.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Element" ApplyToDerivedTypes="True">
+                <Setter Property="Shell.BackgroundColor" Value="{AppThemeBinding Light={StaticResource SurfaceColor}, Dark={StaticResource SurfaceDarkColor}}" />
+                <Setter Property="Shell.ForegroundColor" Value="{StaticResource PrimaryTextColor}" />
+            </Style>
+        </ResourceDictionary>
+    </Shell.Resources>
+
+    <FlyoutItem Title="Inicio" Route="Inicio">
+        <ShellContent ContentTemplate="{DataTemplate views:InicioPage}" />
+    </FlyoutItem>
+    <FlyoutItem Title="Materiales" Route="Materiales">
+        <ShellContent ContentTemplate="{DataTemplate views:MaterialesPage}" />
+    </FlyoutItem>
+    <FlyoutItem Title="Stock" Route="Stock">
+        <ShellContent ContentTemplate="{DataTemplate views:StockPage}" />
+    </FlyoutItem>
+    <FlyoutItem Title="Acopio" Route="Acopio">
+        <ShellContent ContentTemplate="{DataTemplate views:AcopioPage}" />
+    </FlyoutItem>
+    <FlyoutItem Title="Clientes" Route="Clientes">
+        <ShellContent ContentTemplate="{DataTemplate views:ClientesPage}" />
+    </FlyoutItem>
+</Shell>

--- a/MaterialManagerApp/AppShell.xaml.cs
+++ b/MaterialManagerApp/AppShell.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp;
+
+public partial class AppShell : Shell
+{
+    public AppShell()
+    {
+        InitializeComponent();
+    }
+}

--- a/MaterialManagerApp/Converters/BoolToColorConverter.cs
+++ b/MaterialManagerApp/Converters/BoolToColorConverter.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Converters;
+
+public class BoolToColorConverter : IValueConverter
+{
+    public Color TrueColor { get; set; } = Color.FromArgb("#B00020");
+    public Color FalseColor { get; set; } = Color.FromArgb("#1B5E20");
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool flag)
+        {
+            return flag ? TrueColor : FalseColor;
+        }
+
+        return FalseColor;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/MaterialManagerApp/Converters/NullToBoolConverter.cs
+++ b/MaterialManagerApp/Converters/NullToBoolConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Converters;
+
+public class NullToBoolConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string text)
+        {
+            return !string.IsNullOrWhiteSpace(text);
+        }
+
+        return value is not null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/MaterialManagerApp/MaterialManagerApp.csproj
+++ b/MaterialManagerApp/MaterialManagerApp.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0-android</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MaterialManagerApp</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ApplicationTitle>Gestor de Materiales</ApplicationTitle>
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiXaml Update="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <DependentUpon>App.xaml</DependentUpon>
+    </MauiXaml>
+    <MauiXaml Update="AppShell.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <DependentUpon>AppShell.xaml</DependentUpon>
+    </MauiXaml>
+    <MauiXaml Update="Views/*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Resources/Styles/*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+  </ItemGroup>
+</Project>

--- a/MaterialManagerApp/MauiProgram.cs
+++ b/MaterialManagerApp/MauiProgram.cs
@@ -1,0 +1,16 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
+
+namespace MaterialManagerApp;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder.UseMauiApp<App>();
+
+        return builder.Build();
+    }
+}

--- a/MaterialManagerApp/Models/Material.cs
+++ b/MaterialManagerApp/Models/Material.cs
@@ -1,0 +1,11 @@
+namespace MaterialManagerApp.Models;
+
+public class Material
+{
+    public string Codigo { get; set; } = string.Empty;
+    public string Categoria { get; set; } = string.Empty;
+    public double CantidadInicial { get; set; }
+    public string UnidadMedida { get; set; } = string.Empty;
+    public decimal Precio { get; set; }
+    public double TotalEnStock { get; set; }
+}

--- a/MaterialManagerApp/Services/MaterialService.cs
+++ b/MaterialManagerApp/Services/MaterialService.cs
@@ -1,0 +1,35 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using MaterialManagerApp.Models;
+
+namespace MaterialManagerApp.Services;
+
+public class MaterialService
+{
+    private readonly ObservableCollection<Material> _materiales = new();
+
+    public ObservableCollection<Material> ObtenerMateriales() => _materiales;
+
+    public void Agregar(Material material)
+    {
+        if (string.IsNullOrWhiteSpace(material.Codigo))
+        {
+            throw new ArgumentException("El código es obligatorio", nameof(material));
+        }
+
+        if (_materiales.Any(m => string.Equals(m.Codigo, material.Codigo, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException($"Ya existe un material con el código {material.Codigo}");
+        }
+
+        _materiales.Add(material);
+    }
+
+    public void Eliminar(Material material)
+    {
+        if (_materiales.Contains(material))
+        {
+            _materiales.Remove(material);
+        }
+    }
+}

--- a/MaterialManagerApp/ViewModels/MaterialesViewModel.cs
+++ b/MaterialManagerApp/ViewModels/MaterialesViewModel.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using MaterialManagerApp.Models;
+using MaterialManagerApp.Services;
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.ViewModels;
+
+public class MaterialesViewModel : INotifyPropertyChanged
+{
+    private readonly MaterialService _materialService;
+
+    private string _codigo = string.Empty;
+    private string _categoria = string.Empty;
+    private double _cantidadInicial;
+    private string _unidadMedida = string.Empty;
+    private decimal _precio;
+    private double _totalEnStock;
+    private string? _mensaje;
+    private bool _esError;
+
+    public MaterialesViewModel(MaterialService materialService)
+    {
+        _materialService = materialService;
+        Materiales = _materialService.ObtenerMateriales();
+        AgregarMaterialCommand = new Command(AgregarMaterial);
+        EliminarMaterialCommand = new Command<Material>(EliminarMaterial);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ObservableCollection<Material> Materiales { get; }
+
+    public ICommand AgregarMaterialCommand { get; }
+
+    public ICommand EliminarMaterialCommand { get; }
+
+    public string Codigo
+    {
+        get => _codigo;
+        set => SetProperty(ref _codigo, value);
+    }
+
+    public string Categoria
+    {
+        get => _categoria;
+        set => SetProperty(ref _categoria, value);
+    }
+
+    public double CantidadInicial
+    {
+        get => _cantidadInicial;
+        set => SetProperty(ref _cantidadInicial, value);
+    }
+
+    public string UnidadMedida
+    {
+        get => _unidadMedida;
+        set => SetProperty(ref _unidadMedida, value);
+    }
+
+    public decimal Precio
+    {
+        get => _precio;
+        set => SetProperty(ref _precio, value);
+    }
+
+    public double TotalEnStock
+    {
+        get => _totalEnStock;
+        set => SetProperty(ref _totalEnStock, value);
+    }
+
+    public string? Mensaje
+    {
+        get => _mensaje;
+        private set => SetProperty(ref _mensaje, value);
+    }
+
+    public bool EsError
+    {
+        get => _esError;
+        private set => SetProperty(ref _esError, value);
+    }
+
+    private void AgregarMaterial()
+    {
+        try
+        {
+            var material = new Material
+            {
+                Codigo = Codigo.Trim(),
+                Categoria = Categoria.Trim(),
+                CantidadInicial = CantidadInicial,
+                UnidadMedida = UnidadMedida.Trim(),
+                Precio = Precio,
+                TotalEnStock = TotalEnStock
+            };
+
+            _materialService.Agregar(material);
+            LimpiarFormulario();
+            EsError = false;
+            Mensaje = "Material agregado correctamente";
+        }
+        catch (Exception ex)
+        {
+            EsError = true;
+            Mensaje = ex.Message;
+        }
+    }
+
+    private void EliminarMaterial(Material? material)
+    {
+        if (material is null)
+        {
+            return;
+        }
+
+        _materialService.Eliminar(material);
+        Mensaje = $"Material {material.Codigo} eliminado";
+        EsError = false;
+    }
+
+    private void LimpiarFormulario()
+    {
+        Codigo = string.Empty;
+        Categoria = string.Empty;
+        CantidadInicial = 0;
+        UnidadMedida = string.Empty;
+        Precio = 0;
+        TotalEnStock = 0;
+    }
+
+    private void SetProperty<T>(ref T backingStore, T value, [CallerMemberName] string propertyName = "")
+    {
+        if (EqualityComparer<T>.Default.Equals(backingStore, value))
+        {
+            return;
+        }
+
+        backingStore = value;
+        OnPropertyChanged(propertyName);
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string propertyName = "")
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/MaterialManagerApp/Views/AcopioPage.xaml
+++ b/MaterialManagerApp/Views/AcopioPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MaterialManagerApp.Views.AcopioPage"
+             Title="Acopio">
+    <Grid Padding="24">
+        <Label Text="Sección de acopios" Style="{StaticResource TitleStyle}" />
+    </Grid>
+</ContentPage>

--- a/MaterialManagerApp/Views/AcopioPage.xaml.cs
+++ b/MaterialManagerApp/Views/AcopioPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Views;
+
+public partial class AcopioPage : ContentPage
+{
+    public AcopioPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/MaterialManagerApp/Views/ClientesPage.xaml
+++ b/MaterialManagerApp/Views/ClientesPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MaterialManagerApp.Views.ClientesPage"
+             Title="Clientes">
+    <Grid Padding="24">
+        <Label Text="Gestión de clientes" Style="{StaticResource TitleStyle}" />
+    </Grid>
+</ContentPage>

--- a/MaterialManagerApp/Views/ClientesPage.xaml.cs
+++ b/MaterialManagerApp/Views/ClientesPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Views;
+
+public partial class ClientesPage : ContentPage
+{
+    public ClientesPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/MaterialManagerApp/Views/InicioPage.xaml
+++ b/MaterialManagerApp/Views/InicioPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MaterialManagerApp.Views.InicioPage"
+             Title="Inicio">
+    <ScrollView>
+        <VerticalStackLayout Padding="24" Spacing="16">
+            <Label Text="Bienvenido al gestor de materiales" Style="{StaticResource TitleStyle}" />
+            <Label Text="Desde aquí podrás administrar los materiales, controlar el stock, gestionar acopios y clientes." LineBreakMode="WordWrap" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/MaterialManagerApp/Views/InicioPage.xaml.cs
+++ b/MaterialManagerApp/Views/InicioPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Views;
+
+public partial class InicioPage : ContentPage
+{
+    public InicioPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/MaterialManagerApp/Views/MaterialesPage.xaml
+++ b/MaterialManagerApp/Views/MaterialesPage.xaml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MaterialManagerApp.Views.MaterialesPage"
+             Title="Materiales">
+    <ScrollView>
+        <VerticalStackLayout Padding="24" Spacing="20">
+            <Label Text="Administración de materiales" Style="{StaticResource TitleStyle}" />
+            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                <Label Text="Código" Grid.Row="0" Grid.Column="0" VerticalTextAlignment="Center" />
+                <Entry Grid.Row="0" Grid.Column="1" Placeholder="Ej: MAT-001" Text="{Binding Codigo}" />
+
+                <Label Text="Categoría" Grid.Row="1" Grid.Column="0" VerticalTextAlignment="Center" />
+                <Entry Grid.Row="1" Grid.Column="1" Placeholder="Ej: Hormigón" Text="{Binding Categoria}" />
+
+                <Label Text="Cantidad Inicial" Grid.Row="2" Grid.Column="0" VerticalTextAlignment="Center" />
+                <Entry Grid.Row="2" Grid.Column="1" Keyboard="Numeric" Text="{Binding CantidadInicial}" />
+
+                <Label Text="Unidad de medida" Grid.Row="3" Grid.Column="0" VerticalTextAlignment="Center" />
+                <Entry Grid.Row="3" Grid.Column="1" Placeholder="Ej: m³" Text="{Binding UnidadMedida}" />
+
+                <Label Text="Precio" Grid.Row="4" Grid.Column="0" VerticalTextAlignment="Center" />
+                <Entry Grid.Row="4" Grid.Column="1" Keyboard="Numeric" Text="{Binding Precio}" />
+
+                <Label Text="Total en Stock" Grid.Row="5" Grid.Column="0" VerticalTextAlignment="Center" />
+                <Entry Grid.Row="5" Grid.Column="1" Keyboard="Numeric" Text="{Binding TotalEnStock}" />
+            </Grid>
+
+            <Button Text="Agregar material" Command="{Binding AgregarMaterialCommand}" />
+
+            <Border StrokeThickness="1" Stroke="#cccccc" Padding="12" IsVisible="{Binding Mensaje, Converter={StaticResource NullToBoolConverter}}">
+                <Label Text="{Binding Mensaje}" TextColor="{Binding EsError, Converter={StaticResource BoolToColorConverter}}" />
+            </Border>
+
+            <CollectionView ItemsSource="{Binding Materiales}">
+                <CollectionView.Header>
+                    <Grid ColumnDefinitions="2*,*,*,*,*,Auto" Padding="0,0,0,8">
+                        <Label Text="Código" FontAttributes="Bold" />
+                        <Label Text="Categoría" FontAttributes="Bold" Grid.Column="1" />
+                        <Label Text="Cantidad" FontAttributes="Bold" Grid.Column="2" />
+                        <Label Text="Unidad" FontAttributes="Bold" Grid.Column="3" />
+                        <Label Text="Precio" FontAttributes="Bold" Grid.Column="4" />
+                        <Label Text="Stock" FontAttributes="Bold" Grid.Column="5" />
+                    </Grid>
+                </CollectionView.Header>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid ColumnDefinitions="2*,*,*,*,*,Auto" Padding="0,6">
+                            <Label Text="{Binding Codigo}" />
+                            <Label Text="{Binding Categoria}" Grid.Column="1" />
+                            <Label Text="{Binding CantidadInicial}" Grid.Column="2" />
+                            <Label Text="{Binding UnidadMedida}" Grid.Column="3" />
+                            <Label Text="{Binding Precio, StringFormat='{}{0:C}'}" Grid.Column="4" />
+                            <Label Text="{Binding TotalEnStock}" Grid.Column="5" />
+                            <Button Text="Eliminar"
+                                    Grid.Column="6"
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.EliminarMaterialCommand}"
+                                    CommandParameter="{Binding .}" />
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+                <CollectionView.EmptyView>
+                    <StackLayout Padding="12" HorizontalOptions="Center">
+                        <Label Text="No hay materiales cargados" />
+                    </StackLayout>
+                </CollectionView.EmptyView>
+            </CollectionView>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/MaterialManagerApp/Views/MaterialesPage.xaml.cs
+++ b/MaterialManagerApp/Views/MaterialesPage.xaml.cs
@@ -1,0 +1,14 @@
+using MaterialManagerApp.Services;
+using MaterialManagerApp.ViewModels;
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Views;
+
+public partial class MaterialesPage : ContentPage
+{
+    public MaterialesPage()
+    {
+        InitializeComponent();
+        BindingContext ??= new MaterialesViewModel(new MaterialService());
+    }
+}

--- a/MaterialManagerApp/Views/StockPage.xaml
+++ b/MaterialManagerApp/Views/StockPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MaterialManagerApp.Views.StockPage"
+             Title="Stock">
+    <Grid Padding="24">
+        <Label Text="Sección de stock" Style="{StaticResource TitleStyle}" />
+    </Grid>
+</ContentPage>

--- a/MaterialManagerApp/Views/StockPage.xaml.cs
+++ b/MaterialManagerApp/Views/StockPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace MaterialManagerApp.Views;
+
+public partial class StockPage : ContentPage
+{
+    public StockPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Resources/Styles/Colors.xaml
+++ b/Resources/Styles/Colors.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="PrimaryColor">#006494</Color>
+    <Color x:Key="PrimaryDarkColor">#004E73</Color>
+    <Color x:Key="SurfaceColor">#FFFFFF</Color>
+    <Color x:Key="SurfaceDarkColor">#1E1E1E</Color>
+    <Color x:Key="PrimaryTextColor">#111111</Color>
+    <Color x:Key="ErrorColor">#B00020</Color>
+    <Color x:Key="SuccessColor">#1B5E20</Color>
+</ResourceDictionary>

--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:converters="clr-namespace:MaterialManagerApp.Converters;assembly=MaterialManagerApp">
+    <converters:NullToBoolConverter x:Key="NullToBoolConverter" />
+    <converters:BoolToColorConverter x:Key="BoolToColorConverter"
+                                     TrueColor="{StaticResource ErrorColor}"
+                                     FalseColor="{StaticResource SuccessColor}" />
+
+    <Style TargetType="ContentPage">
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource SurfaceColor}, Dark={StaticResource SurfaceDarkColor}}" />
+    </Style>
+
+    <Style x:Key="TitleStyle" TargetType="Label">
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="TextColor" Value="{StaticResource PrimaryColor}" />
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- scaffold a .NET MAUI Android solution with Shell navigation for Inicio, Materiales, Stock, Acopio y Clientes
- build a Materiales page with form bindings, collection view and commands to agregar y eliminar materiales
- add view models, services, converters y recursos de estilos para soportar la interfaz en español

## Testing
- not run (dotnet CLI no disponible en el entorno)


------
https://chatgpt.com/codex/tasks/task_e_68daa784d448832cb67b4b92a1b62863